### PR TITLE
RawDoc: Ignore comments starting with four slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Ignore comments starting with four slashes in documentation.
 
 ## 0.5.0 - 2020-04-10
 ### Changed

--- a/src/doc/raw.rs
+++ b/src/doc/raw.rs
@@ -41,7 +41,7 @@ impl<'a> RawDoc<'a> {
                             }
                             last_comment = LastComment::Parent;
                             comments.push(&s[3..]);
-                        } else if s.starts_with("///") {
+                        } else if s.starts_with("///") && !s.starts_with("////") {
                             if !comments.is_empty() && last_comment != LastComment::Local {
                                 comments.push("");
                             }


### PR DESCRIPTION
Rationale: Docstrings have three slashes followed by a non-slash character.  Four our more slashes are used, e.g., in visual delimiters, which should not go into documentation.