### PR TITLE
html::Renderer: Emit unique `id`s for ports, parameters, and signals

### DIFF
--- a/src/doc/html/mod.rs
+++ b/src/doc/html/mod.rs
@@ -224,7 +224,7 @@ impl<'a> Renderer<'a> {
             for i in &cx.params {
                 write!(
                     out,
-                    "<h3 id=\"impl\" class=\"impl\"><code class=\"in-band\">{}</code></h3>",
+                    "<h3 id=\"parameter.{0}\" class=\"impl\"><code class=\"in-band\">{0}</code></h3>",
                     i.name
                 )?;
                 write!(out, "<div class=\"docblock\"\n>")?;
@@ -237,7 +237,7 @@ impl<'a> Renderer<'a> {
             for i in &cx.ports {
                 write!(
                     out,
-                    "<h3 id=\"impl\" class=\"impl\"><code class=\"in-band\">{}</code></h3>",
+                    "<h3 id=\"port.{0}\" class=\"impl\"><code class=\"in-band\">{0}</code></h3>",
                     i.name
                 )?;
                 write!(out, "<div class=\"docblock\"\n>")?;
@@ -267,7 +267,7 @@ impl<'a> Renderer<'a> {
             for i in &cx.vars {
                 write!(
                     out,
-                    "<h3 id=\"impl\" class=\"impl\"><code class=\"in-band\">{}: {}</code></h3>",
+                    "<h3 id=\"signal.{0}\" class=\"impl\"><code class=\"in-band\">{0}: {1}</code></h3>",
                     i.name, i.ty
                 )?;
                 write!(out, "<div class=\"docblock\"\n>")?;

--- a/src/doc/html/mod.rs
+++ b/src/doc/html/mod.rs
@@ -186,7 +186,7 @@ impl<'a> Renderer<'a> {
 
     fn render_contents(&mut self, cx: &Context, out: &mut impl Write) -> Result<()> {
         if !cx.packages.is_empty() {
-            write!(out, "<h2>Packages</h2>\n")?;
+            write!(out, "<h2 id=\"packages\">Packages</h2>\n")?;
             write!(out, "<table>\n")?;
             for i in &cx.packages {
                 write!(
@@ -203,7 +203,7 @@ impl<'a> Renderer<'a> {
             write!(out, "</table>\n")?;
         }
         if !cx.modules.is_empty() {
-            write!(out, "<h2>Modules</h2>\n")?;
+            write!(out, "<h2 id=\"modules\">Modules</h2>\n")?;
             write!(out, "<table>\n")?;
             for i in &cx.modules {
                 write!(
@@ -220,7 +220,7 @@ impl<'a> Renderer<'a> {
             write!(out, "</table>\n")?;
         }
         if !cx.params.is_empty() {
-            write!(out, "<h2>Parameters</h2>\n")?;
+            write!(out, "<h2 id=\"parameters\">Parameters</h2>\n")?;
             for i in &cx.params {
                 write!(
                     out,
@@ -233,7 +233,7 @@ impl<'a> Renderer<'a> {
             }
         }
         if !cx.ports.is_empty() {
-            write!(out, "<h2>Ports</h2>\n")?;
+            write!(out, "<h2 id=\"ports\">Ports</h2>\n")?;
             for i in &cx.ports {
                 write!(
                     out,
@@ -246,7 +246,7 @@ impl<'a> Renderer<'a> {
             }
         }
         if !cx.types.is_empty() {
-            write!(out, "<h2>Types</h2>\n")?;
+            write!(out, "<h2 id=\"types\">Types</h2>\n")?;
             write!(out, "<table>\n")?;
             for i in &cx.types {
                 write!(
@@ -263,7 +263,7 @@ impl<'a> Renderer<'a> {
             write!(out, "</table>\n")?;
         }
         if !cx.vars.is_empty() {
-            write!(out, "<h2>Signals</h2>\n")?;
+            write!(out, "<h2 id=\"signals\">Signals</h2>\n")?;
             for i in &cx.vars {
                 write!(
                     out,


### PR DESCRIPTION
This allows to link to an element within a documentation page with `#id`.

@fabianschuiki It would be extra nice if we could let paragraph "anchor" symbols appear that users can click to get the direct link to an element (like on docs.rs). :slightly_smiling_face: I tried adding the HTML code for that, but there seems to be a script or CSS file missing -- any idea which?