### PR TITLE
Support loading library files (lazily)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@
 #[macro_use]
 extern crate log;
 
-use anyhow::{Context as _, Error, Result};
+use anyhow::{anyhow, Context as _, Error, Result};
 use clap::{App, Arg};
 use log::LevelFilter;
 use rayon::prelude::*;
@@ -15,14 +15,14 @@ use serde::{Deserialize, Serialize};
 use simple_logger::SimpleLogger;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
+use std::ffi::OsStr;
 use std::fs::File;
-use std::path::Path;
 use std::io;
 use std::io::Write;
 use std::io::{BufReader, BufWriter};
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::ffi::OsStr;
 use sv_parser::preprocess;
 use sv_parser::Error as SvParserError;
 use sv_parser::{parse_sv_pp, unwrap_node, Define, DefineText, Locate, RefNode, SyntaxTree};
@@ -48,6 +48,8 @@ struct Pickle<'a> {
     replace_table: Vec<(usize, usize, String)>,
     /// A set of instantiated modules.
     inst_table: HashSet<String>,
+    /// Information for library files
+    libs: LibraryBundle,
 }
 
 impl<'a> Pickle<'a> {
@@ -94,6 +96,41 @@ impl<'a> Pickle<'a> {
             debug!("Exclude `{}`: {:?}", inst_name, loc);
             self.replace_table
                 .push((locate.offset, locate.len, "".to_string()));
+        }
+    }
+
+    fn load_library_module(&mut self, module_name: &str) {
+        if let Ok(pf) = self.libs.load_module(module_name) {
+            for node in &pf.ast {
+                match node {
+                    // Module declarations.
+                    RefNode::ModuleDeclarationAnsi(x) => {
+                        // unwrap_node! gets the nearest ModuleIdentifier from x
+                        let id = unwrap_node!(x, SimpleIdentifier).unwrap();
+                        self.register_declaration(&pf.ast, id);
+                    }
+                    RefNode::ModuleDeclarationNonansi(x) => {
+                        let id = unwrap_node!(x, SimpleIdentifier).unwrap();
+                        self.register_declaration(&pf.ast, id);
+                    }
+                    _ => (),
+                }
+            }
+            for node in &pf.ast {
+                match node {
+                    RefNode::ModuleInstantiation(x) => {
+                        let id = unwrap_node!(x, SimpleIdentifier).unwrap();
+                        self.register_instantiation(&pf.ast, id.clone());
+
+                        let (inst_name, _) = get_identifier(&pf.ast, id);
+                        info!("Instantiation in library module {}", &inst_name);
+                        if !self.rename_table.contains_key(&inst_name) {
+                            self.load_library_module(&inst_name);
+                        }
+                    }
+                    _ => (),
+                }
+            }
         }
     }
 }
@@ -325,6 +362,7 @@ fn main() -> Result<()> {
         rename_table: HashMap::new(),
         replace_table: vec![],
         inst_table: HashSet::new(),
+        libs: library_bundle,
     };
 
     // Parse the input files.
@@ -359,32 +397,12 @@ fn main() -> Result<()> {
             .files
             .par_iter()
             .map(|filename| -> Result<_> {
-                info!("{:?}", filename);
-
-                // Preprocess the verilog files.
-                let pp = preprocess(
-                    filename,
-                    &bundle_defines,
+                parse_file(
+                    &filename,
                     &bundle_include_dirs,
+                    &bundle_defines,
                     strip_comments,
-                    false,
                 )
-                .with_context(|| format!("Failed to preprocess `{}`", filename))?;
-
-                let buffer = pp.0.text().to_string();
-                let syntax_tree = parse_sv_pp(pp.0, pp.1, false)
-                    .or_else(|err| -> Result<_> {
-                        let mut printer = &mut *printer.lock().unwrap();
-                        print_parse_error(&mut printer, &err, false)?;
-                        Err(Error::new(err))
-                    })?
-                    .0;
-
-                Ok(ParsedFile {
-                    path: filename.clone(),
-                    source: buffer,
-                    ast: syntax_tree,
-                })
             })
             .collect();
         syntax_trees.extend(v?);
@@ -459,7 +477,13 @@ fn main() -> Result<()> {
             match node {
                 RefNode::ModuleInstantiation(x) => {
                     let id = unwrap_node!(x, SimpleIdentifier).unwrap();
-                    pickle.register_instantiation(&pf.ast, id);
+                    pickle.register_instantiation(&pf.ast, id.clone());
+
+                    let (inst_name, _) = get_identifier(&pf.ast, id);
+                    if !pickle.rename_table.contains_key(&inst_name) {
+                        info!("could not find {}", &inst_name);
+                        pickle.load_library_module(&inst_name);
+                    }
                 }
                 // Instantiations, end-labels.
                 RefNode::ModuleIdentifier(x) => {
@@ -549,6 +573,40 @@ fn lib_module(p: &Path) -> Option<String> {
     p.with_extension("").file_name()?.to_str().map(String::from)
 }
 
+fn parse_file(
+    filename: &str,
+    bundle_include_dirs: &Vec<&Path>,
+    bundle_defines: &HashMap<String, Option<Define>>,
+    strip_comments: bool,
+) -> Result<ParsedFile> {
+    info!("{:?}", filename);
+
+    // Preprocess the verilog files.
+    let pp = preprocess(
+        filename,
+        &bundle_defines,
+        &bundle_include_dirs,
+        strip_comments,
+        false,
+    )
+    .with_context(|| format!("Failed to preprocess `{}`", filename))?;
+
+    let buffer = pp.0.text().to_string();
+    let syntax_tree = parse_sv_pp(pp.0, pp.1, false)
+        .or_else(|err| -> Result<_> {
+            // let mut printer = &mut *printer.lock().unwrap();
+            // print_parse_error(&mut printer, &err, false)?;
+            Err(Error::new(err))
+        })?
+        .0;
+
+    Ok(ParsedFile {
+        path: String::from(filename),
+        source: buffer,
+        ast: syntax_tree,
+    })
+}
+
 fn get_identifier(st: &SyntaxTree, node: RefNode) -> (String, Locate) {
     // unwrap_node! can take multiple types
     match unwrap_node!(node, SimpleIdentifier, EscapedIdentifier) {
@@ -570,10 +628,42 @@ struct FileBundle {
     files: Vec<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
 struct LibraryBundle {
     include_dirs: Vec<String>,
     defines: HashMap<String, Option<String>>,
     files: HashMap<String, PathBuf>,
+}
+
+impl LibraryBundle {
+    fn load_module(&self, module_name: &str) -> Result<ParsedFile, Error> {
+        let f = match self.files.get(module_name) {
+            Some(p) => p.to_string_lossy(),
+            None => {
+                return Err(anyhow!("module {} not found in libraries", module_name));
+            }
+        };
+
+        let bundle_include_dirs: Vec<_> = self.include_dirs.iter().map(Path::new).collect();
+        // Convert the preprocessor defines into the appropriate format which is understood by `sv-parser`
+        let bundle_defines: HashMap<_, _> = self
+            .defines
+            .iter()
+            .map(|(name, value)| {
+                // If there is a define text add it.
+                let define_text = match value {
+                    Some(x) => Some(DefineText::new(String::from(x), None)),
+                    None => None,
+                };
+                (
+                    name.clone(),
+                    Some(Define::new(name.clone(), vec![], define_text)),
+                )
+            })
+            .collect();
+
+        return parse_file(&f, &bundle_include_dirs, &bundle_defines, true);
+    }
 }
 
 /// A parsed input file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,13 @@ use std::convert::TryFrom;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io;
-use std::io::{Write, BufReader, BufWriter};
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use sv_parser::Error as SvParserError;
-use sv_parser::{preprocess, parse_sv_pp, unwrap_node, Define, DefineText, Locate, RefNode, SyntaxTree};
+use sv_parser::{
+    parse_sv_pp, preprocess, unwrap_node, Define, DefineText, Locate, RefNode, SyntaxTree,
+};
 
 pub mod doc;
 mod printer;
@@ -125,7 +127,10 @@ impl<'a> Pickle<'a> {
                         // if this module is undefined, recursively attempt to load a library
                         // module for it.
                         let (inst_name, _) = get_identifier(&pf.ast, id);
-                        info!("Instantiation `{}` in library module `{}`", &inst_name, &module_name);
+                        info!(
+                            "Instantiation `{}` in library module `{}`",
+                            &inst_name, &module_name
+                        );
                         if !self.rename_table.contains_key(&inst_name) {
                             self.load_library_module(&inst_name, files);
                         }
@@ -581,7 +586,9 @@ fn lib_module(p: &Path) -> Option<String> {
 }
 
 // Convert the preprocessor defines into the appropriate format which is understood by `sv-parser`
-fn defines_to_sv_parser(defines: &HashMap<String, Option<String>>) -> HashMap<String, Option<Define>> {
+fn defines_to_sv_parser(
+    defines: &HashMap<String, Option<String>>,
+) -> HashMap<String, Option<Define>> {
     return defines
         .iter()
         .map(|(name, value)| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ impl<'a> Pickle<'a> {
                         // if this module is undefined, recursively attempt to load a library
                         // module for it.
                         let (inst_name, _) = get_identifier(&pf.ast, id);
-                        info!("Instantiation in library module {}", &inst_name);
+                        info!("Instantiation `{}` in library module `{}`", &inst_name, &module_name);
                         if !self.rename_table.contains_key(&inst_name) {
                             self.load_library_module(&inst_name, files);
                         }


### PR DESCRIPTION
This PR adds two new options: `--library-dir DIR` and `--library-file FILE` (similar to `-y` and `-v` from Verilator or other Verilog tools). Files in the specified directory or given directly via `--library-file` are accumulated into a hashmap mapping "module name" to "path" (a file at `/path/to/xxx.sv` will have "module name" `xxx` and "path" `/path/to/xxx.sv`). Library files should contain one module and have the filename (without extension) be the same as the module name. During pickling, if a module is not found Morty will check the hashmap and if it contains the module name Morty will load and pickle the file at the corresponding path. Loading one library file may cause others to be loaded if the original library file uses modules from other library files.

Summary of code changes:

Since this change requires parsing files during pickling I have split the parse file logic into a separate function called `parse_file`, and the logic to convert defines to the `sv-parser` into a separate function called `defines_to_sv_parser`. The `LibraryBundle` type stores the hashmap and is stored in the `Pickle` object. The `Pickle` struct now has an additional method, `load_library_module`, which looks up the module in the library bundle, parses it, recursively loads other library modules if necessary, and then adds the resulting `ParsedFile` to a list. This list is then appended to the `syntax_trees` list before the final pass to emit all pickled files.

Let me know if you would like me to make any changes.