### PR TITLE
Add option to output a manifest

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,8 +145,8 @@ impl<'a> Pickle<'a> {
                 }
                 // add the parsed file to the vector.
                 files.push(pf);
-            },
-            Err(e) => info!("error loading library: {}", e)
+            }
+            Err(e) => info!("error loading library: {}", e),
         }
     }
 }
@@ -596,17 +596,18 @@ fn main() -> Result<()> {
             }
         }
         base_files.extend(pickle.used_libs.clone());
-        bundles.push(FileBundle{
+        bundles.push(FileBundle {
             include_dirs: include_dirs.clone(),
             defines: defines.clone(),
             files: base_files,
         });
 
-        let json = serde_json::to_string_pretty(&Manifest{
+        let json = serde_json::to_string_pretty(&Manifest {
             sources: bundles,
             tops: top_modules,
             undefined: undef_modules,
-        }).unwrap();
+        })
+        .unwrap();
 
         let path = Path::new(manifest_file);
         let mut out = Box::new(BufWriter::new(File::create(&path).unwrap())) as Box<dyn Write>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -603,7 +603,7 @@ fn main() -> Result<()> {
         });
 
         let json = serde_json::to_string_pretty(&Manifest{
-            files: bundles,
+            sources: bundles,
             tops: top_modules,
             undefined: undef_modules,
         }).unwrap();
@@ -703,7 +703,7 @@ fn get_identifier(st: &SyntaxTree, node: RefNode) -> (String, Locate) {
 #[derive(Serialize, Deserialize, Debug)]
 struct Manifest {
     // list of file bundles
-    files: Vec<FileBundle>,
+    sources: Vec<FileBundle>,
     // list of top modules
     tops: Vec<String>,
     // list of undefined modules

--- a/src/main.rs
+++ b/src/main.rs
@@ -586,17 +586,24 @@ fn main() -> Result<()> {
             }
         }
 
-        // bundle the library files that were used
-        let lib_bundle = FileBundle{
+        let mut base_files = Vec::new();
+        let mut bundles = Vec::new();
+        for bundle in file_list {
+            if bundle.include_dirs == include_dirs && bundle.defines == defines {
+                base_files.extend(bundle.files.clone());
+            } else {
+                bundles.push(bundle);
+            }
+        }
+        base_files.extend(pickle.used_libs.clone());
+        bundles.push(FileBundle{
             include_dirs: include_dirs.clone(),
             defines: defines.clone(),
-            files: pickle.used_libs.clone(),
-        };
-
-        file_list.push(lib_bundle);
+            files: base_files,
+        });
 
         let json = serde_json::to_string_pretty(&Manifest{
-            files: file_list,
+            files: bundles,
             tops: top_modules,
             undefined: undef_modules,
         }).unwrap();


### PR DESCRIPTION
This PR replaces the previous `--write-undefined` functionality with a more comprehensive solution. Users can pass `--manifest file.json`, and morty will write information to `file.json`, including the file list (including auto-detected library files), a list of undefined modules, and a list of top-level modules. This approach is cleaner than `--write-undefined`, provides more information (file list and top modules), and allows for future expansion as well.

For example, running morty on a small cpu design I have with various options (`-y`, `-D`, `-I`) generated the following manifest:

```json
{
  "sources": [
    {
      "include_dirs": [
        "hdl"
      ],
      "defines": {
        "SYNTHESIS": null
      },
      "files": [
        "hdl/cpu_top.sv",
        "hdl/rw_ram.sv",
        "hdl/cpu.sv",
        "hdl/control.sv",
        "hdl/reg_reset.sv",
        "hdl/reg_file.sv",
        "hdl/alu.sv",
      ]
    }
  ],
  "tops": [
    "cpu_top"
  ],
  "undefined": []
}
```