### PR TITLE
Adjust format for bender >= 0.24

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -368,6 +368,9 @@ fn main() -> Result<()> {
             process::exit(1)
         });
         for fb in &mut u {
+            for (_k, v) in fb.export_incdirs.clone() {
+                fb.include_dirs.extend(v);
+            }
             fb.defines.extend(defines.clone());
             fb.include_dirs.extend(include_dirs.clone());
         }
@@ -377,6 +380,7 @@ fn main() -> Result<()> {
     if let Some(file_names) = matches.values_of("INPUT") {
         file_list.push(FileBundle {
             include_dirs: include_dirs.clone(),
+            export_incdirs: HashMap::new(),
             defines: defines.clone(),
             files: file_names.map(String::from).collect(),
         });
@@ -611,6 +615,7 @@ fn main() -> Result<()> {
         base_files.extend(pickle.used_libs.clone());
         bundles.push(FileBundle {
             include_dirs: include_dirs.clone(),
+            export_incdirs: HashMap::new(),
             defines: defines.clone(),
             files: base_files,
         });
@@ -727,6 +732,9 @@ struct Manifest {
 #[derive(Serialize, Deserialize, Debug)]
 struct FileBundle {
     include_dirs: Vec<String>,
+
+    #[serde(default)]
+    export_incdirs: HashMap<String, Vec<String>>,
     defines: HashMap<String, Option<String>>,
     files: Vec<String>,
 }


### PR DESCRIPTION
Bender changed how `export_incdirs` are handled, which is correspondingly adjusted here when importing a json format source file list.